### PR TITLE
[PROJ-32] Find Project button not switching projects

### DIFF
--- a/src/components/custom-drawer/CustomDrawer.js
+++ b/src/components/custom-drawer/CustomDrawer.js
@@ -24,7 +24,7 @@ const CustomDrawer = props => {
 
     const closeDrawer = item => {
         setSearch('');
-        view === 'projects' && typeof item === 'string' ? switchProjectViewed(item) : onClose(false)
+        view === 'projects' ? switchProjectViewed(item) : onClose(false)
     };
 
     return (


### PR DESCRIPTION
## Task
[PROJ-32](https://project-tracker-k47j.onrender.com/task/PROJ-32)

## Description
The button to switch between projects on the index page was not behaving as intended. When a project was selected, it would close the drawer, but would not update the tasks displayed in order to show the tasks in the project chosen.

This fixes the ternary condition in the closeDrawer() function of `CustomDrawer.js` and ensures that the tasks displayed will update when a project is chosen.